### PR TITLE
Update API to return random number between 1 and 50

### DIFF
--- a/simple_api.py
+++ b/simple_api.py
@@ -5,7 +5,7 @@ app = Flask(__name__)
 @app.route('/api/fixed', methods=['GET'])
 def fixed_value():
     import random
-    random_number = random.randint(1, 100)
+    random_number = random.randint(1, 50)
     return jsonify({"random_number": random_number})
 
 if __name__ == '__main__':

--- a/test_simple_api.py
+++ b/test_simple_api.py
@@ -12,7 +12,7 @@ class SimpleApiTestCase(unittest.TestCase):
         self.assertIn("random_number", response.json)
         self.assertIsInstance(response.json["random_number"], int)
         self.assertGreaterEqual(response.json["random_number"], 1)
-        self.assertLessEqual(response.json["random_number"], 100)
+        self.assertLessEqual(response.json["random_number"], 50)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR updates the API to return a random number between 1 and 50 and adjusts the test cases accordingly.