### PR TITLE
Add FastAPI hello world endpoint

### DIFF
--- a/fast_api.py
+++ b/fast_api.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/hello")
+async def read_hello():
+    return {"message": "hello world!"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/test_fast_api.py
+++ b/test_fast_api.py
@@ -1,0 +1,15 @@
+import unittest
+from fastapi.testclient import TestClient
+from fast_api import app
+
+class FastApiTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_hello_world(self):
+        response = self.client.get('/hello')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'message': 'hello world!'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `fast_api.py` with a `/hello` endpoint returning a JSON greeting
- add unit test `test_fast_api.py` verifying the new FastAPI route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `httpx`, `flask`, and `gradio`)*

------
https://chatgpt.com/codex/tasks/task_e_683fff289ad88323a4108c79658955da