### PR TITLE
Update hello_api endpoint

### DIFF
--- a/hello_api.py
+++ b/hello_api.py
@@ -1,10 +1,11 @@
-from flask import Flask
+from flask import Flask, request
 
 app = Flask(__name__)
 
 @app.route('/hello', methods=['GET'])
-def hello_world():
-    return "Hello, World!"
+def hello_codex():
+    name = request.args.get('name', '')
+    return f"{name}Hello, Codex!"
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/test_hello_api.py
+++ b/test_hello_api.py
@@ -6,10 +6,10 @@ class HelloApiTestCase(unittest.TestCase):
         self.app = app.test_client()
         self.app.testing = True
 
-    def test_hello_world(self):
-        response = self.app.get('/hello')
+    def test_hello_codex(self):
+        response = self.app.get('/hello?name=Alice')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.decode('utf-8'), "Hello, World!")
+        self.assertEqual(response.data.decode('utf-8'), "AliceHello, Codex!")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- update `hello_api.py` to accept an optional `name` query parameter
- update `test_hello_api.py` to test the new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840f6a6842c83239d132dd6d773e7b8