### PR TITLE
Implement name-based greeting in hello_api

### DIFF
--- a/hello_api.py
+++ b/hello_api.py
@@ -1,10 +1,14 @@
-from flask import Flask
+from flask import Flask, request
 
 app = Flask(__name__)
 
 @app.route('/hello', methods=['GET'])
 def hello_world():
-    return "Hello, Codex!"
+    name = request.args.get('name')
+    if name:
+        return f"{name} Hello, Codex!"
+    else:
+        return "Hello, World!"
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/test_hello_api.py
+++ b/test_hello_api.py
@@ -9,7 +9,12 @@ class HelloApiTestCase(unittest.TestCase):
     def test_hello_world(self):
         response = self.app.get('/hello')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.decode('utf-8'), "Hello, Codex!")
+        self.assertEqual(response.data.decode('utf-8'), "Hello, World!")
+
+    def test_hello_with_name(self):
+        response = self.app.get('/hello?name=Alice')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.decode('utf-8'), "Alice Hello, Codex!")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `hello_api.py` to return a default greeting when no name is provided
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68412d4073d88323b74c1ca6bc043cf5